### PR TITLE
Add token-manager notifications

### DIFF
--- a/src/TokenSystem.Tests/TestTokenManager.cs
+++ b/src/TokenSystem.Tests/TestTokenManager.cs
@@ -212,7 +212,7 @@ namespace TokenSystem.Tests
 			Address to = this.addresses[0];
 			this.tokenManager.TokensMinted += (sender, args) =>
 			{
-				Assert.Equal(mintAmount, args.Amount);
+				Assert.Equal(mintAmount, args.Tokens.TotalTokens);
 				Assert.Equal(to, args.To);
 			};
 
@@ -228,7 +228,7 @@ namespace TokenSystem.Tests
 
 			this.tokenManager.TokensTransferred += (sender, args) =>
 			{
-				Assert.Equal(transferAmount, args.Amount);
+				Assert.Equal(transferAmount, args.Tokens.TotalTokens);
 				Assert.Equal(from, args.From);
 				Assert.Equal(to, args.To);
 			};
@@ -245,7 +245,7 @@ namespace TokenSystem.Tests
 
 			this.tokenManager.TokensBurned += (sender, args) =>
 			{
-				Assert.Equal(burnAmount, args.Amount);
+				Assert.Equal(burnAmount, args.Tokens.TotalTokens);
 				Assert.Equal(from, args.From);
 			};
 

--- a/src/TokenSystem/TokenEventArgs/TokensBurnedEventArgs.cs
+++ b/src/TokenSystem/TokenEventArgs/TokensBurnedEventArgs.cs
@@ -9,14 +9,11 @@ namespace TokenSystem.TokenEventArgs
 {
 	public class TokensBurnedEventArgs<TTagType> : EventArgs
 	{
-		public TokensBurnedEventArgs(BigInteger amount, IReadOnlyTaggedTokens<TTagType> tokens, Address from)
+		public TokensBurnedEventArgs(IReadOnlyTaggedTokens<TTagType> tokens, Address from)
 		{
-			this.Amount = amount;
 			this.Tokens = tokens;
 			this.From = from;
 		}
-
-		public BigInteger Amount { get; }
 
 		public IReadOnlyTaggedTokens<TTagType> Tokens { get; }
 

--- a/src/TokenSystem/TokenEventArgs/TokensMintedEventArgs.cs
+++ b/src/TokenSystem/TokenEventArgs/TokensMintedEventArgs.cs
@@ -9,14 +9,11 @@ namespace TokenSystem.TokenEventArgs
 {
 	public class TokensMintedEventArgs<TTagType> : EventArgs
 	{
-		public TokensMintedEventArgs(BigInteger amount, IReadOnlyTaggedTokens<TTagType> tokens, Address to)
+		public TokensMintedEventArgs(IReadOnlyTaggedTokens<TTagType> tokens, Address to)
 		{
-			this.Amount = amount;
 			this.Tokens = tokens;
 			this.To = to;
 		}
-
-		public BigInteger Amount { get; }
 
 		public IReadOnlyTaggedTokens<TTagType> Tokens { get; }
 

--- a/src/TokenSystem/TokenEventArgs/TokensTransferredEventArgs.cs
+++ b/src/TokenSystem/TokenEventArgs/TokensTransferredEventArgs.cs
@@ -10,18 +10,14 @@ namespace TokenSystem.TokenEventArgs
 	public class TokensTransferredEventArgs<TTagType> : EventArgs
 	{
 		public TokensTransferredEventArgs(
-			BigInteger amount,
 			IReadOnlyTaggedTokens<TTagType> tokens,
 			Address from,
 			Address to)
 		{
-			this.Amount = amount;
 			this.Tokens = tokens;
 			this.From = from;
 			this.To = to;
 		}
-
-		public BigInteger Amount { get; }
 
 		public IReadOnlyTaggedTokens<TTagType> Tokens { get; }
 

--- a/src/TokenSystem/TokenFlow/OnBurnTokenMinter.cs
+++ b/src/TokenSystem/TokenFlow/OnBurnTokenMinter.cs
@@ -37,7 +37,7 @@ namespace TokenSystem.TokenFlow
 				return;
 			}
 
-			this.Mint(burnArgs.Amount);
+			this.Mint(burnArgs.Tokens.TotalTokens);
 		}
 	}
 }

--- a/src/TokenSystem/TokenFlow/OnTransferTokenBurner.cs
+++ b/src/TokenSystem/TokenFlow/OnTransferTokenBurner.cs
@@ -53,7 +53,7 @@ namespace TokenSystem.TokenFlow
 				return;
 			}
 
-			this.Burn(transferredEventArgs.Amount, transferredEventArgs.To);
+			this.Burn(transferredEventArgs.Tokens.TotalTokens, transferredEventArgs.To);
 		}
 	}
 }

--- a/src/TokenSystem/TokenFlow/UniformTokenSplitter.cs
+++ b/src/TokenSystem/TokenFlow/UniformTokenSplitter.cs
@@ -6,6 +6,7 @@ using ContractsCore;
 using ContractsCore.Events;
 using TokenSystem.TokenManager;
 using TokenSystem.TokenManager.Actions;
+using TokenSystem.Tokens;
 
 namespace TokenSystem.TokenFlow
 {
@@ -24,9 +25,9 @@ namespace TokenSystem.TokenFlow
 		{
 		}
 
-		protected override void Split(BigInteger amount)
+		protected override void Split(IReadOnlyTaggedTokens<TTokenTagType> receivedTokens)
 		{
-			BigInteger splitAmount = amount / this.Recipients.Count;
+			BigInteger splitAmount = receivedTokens.TotalTokens / this.Recipients.Count;
 
 			if (splitAmount <= 0)
 			{

--- a/src/TokenSystem/TokenManager/Actions/TokensBurnedAction.cs
+++ b/src/TokenSystem/TokenManager/Actions/TokensBurnedAction.cs
@@ -1,0 +1,22 @@
+using ContractsCore;
+using ContractsCore.Actions;
+using TokenSystem.Tokens;
+
+namespace TokenSystem.TokenManager.Actions
+{
+	public class TokensBurnedAction<TTokenTagType> : Action
+	{
+		public TokensBurnedAction(
+			string hash,
+			Address origin,
+			Address sender,
+			Address target,
+			IReadOnlyTaggedTokens<TTokenTagType> tokens)
+			: base(hash, origin, sender, target)
+		{
+			this.Tokens = tokens;
+		}
+
+		public IReadOnlyTaggedTokens<TTokenTagType> Tokens { get; }
+	}
+}

--- a/src/TokenSystem/TokenManager/Actions/TokensMintedAction.cs
+++ b/src/TokenSystem/TokenManager/Actions/TokensMintedAction.cs
@@ -1,0 +1,22 @@
+using ContractsCore;
+using ContractsCore.Actions;
+using TokenSystem.Tokens;
+
+namespace TokenSystem.TokenManager.Actions
+{
+	public class TokensMintedAction<TTokenTagType> : Action
+	{
+		public TokensMintedAction(
+			string hash,
+			Address origin,
+			Address sender,
+			Address target,
+			IReadOnlyTaggedTokens<TTokenTagType> tokens)
+			: base(hash, origin, sender, target)
+		{
+			this.Tokens = tokens;
+		}
+
+		public IReadOnlyTaggedTokens<TTokenTagType> Tokens { get; }
+	}
+}

--- a/src/TokenSystem/TokenManager/Actions/TokensReceivedAction.cs
+++ b/src/TokenSystem/TokenManager/Actions/TokensReceivedAction.cs
@@ -1,0 +1,26 @@
+using ContractsCore;
+using ContractsCore.Actions;
+using TokenSystem.Tokens;
+
+namespace TokenSystem.TokenManager.Actions
+{
+	public class TokensReceivedAction<TTokenTagType> : Action
+	{
+		public TokensReceivedAction(
+			string hash,
+			Address origin,
+			Address sender,
+			Address target,
+			Address tokensSender,
+			IReadOnlyTaggedTokens<TTokenTagType> tokens)
+			: base(hash, origin, sender, target)
+		{
+			this.TokensSender = tokensSender;
+			this.Tokens = tokens;
+		}
+
+		public Address TokensSender { get; }
+
+		public IReadOnlyTaggedTokens<TTokenTagType> Tokens { get; }
+	}
+}

--- a/src/TokenSystem/TokenManager/Actions/TokensSentAction.cs
+++ b/src/TokenSystem/TokenManager/Actions/TokensSentAction.cs
@@ -1,0 +1,26 @@
+using ContractsCore;
+using ContractsCore.Actions;
+using TokenSystem.Tokens;
+
+namespace TokenSystem.TokenManager.Actions
+{
+	public class TokensSentAction<TTokenTagType> : Action
+	{
+		public TokensSentAction(
+			string hash,
+			Address origin,
+			Address sender,
+			Address target,
+			Address tokensReceiver,
+			IReadOnlyTaggedTokens<TTokenTagType> tokens)
+			: base(hash, origin, sender, target)
+		{
+			this.TokensReceiver = tokensReceiver;
+			this.Tokens = tokens;
+		}
+
+		public Address TokensReceiver { get; }
+
+		public IReadOnlyTaggedTokens<TTokenTagType> Tokens { get; }
+	}
+}


### PR DESCRIPTION
Add Notification actions to TokenManager, so addresses don't need to explicitly subscribe to events, and check unnecessary transactions